### PR TITLE
Added a tabcompleter for the inventory sync challenge

### DIFF
--- a/src/main/java/com/ciryusmedia/challengenetwork/challengespluginneo/commands/tabcomplete/ChallengeComplete.java
+++ b/src/main/java/com/ciryusmedia/challengenetwork/challengespluginneo/commands/tabcomplete/ChallengeComplete.java
@@ -1,5 +1,8 @@
 package com.ciryusmedia.challengenetwork.challengespluginneo.commands.tabcomplete;
 
+import com.ciryusmedia.challengenetwork.challengespluginneo.ChallengesPluginNeo;
+import com.ciryusmedia.challengenetwork.challengespluginneo.interfaces.Debuglevel;
+import com.ciryusmedia.challengenetwork.challengespluginneo.outsourcing.ChallengesOutsourcing;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.TabCompleter;
@@ -11,34 +14,35 @@ import java.util.List;
 
 public class ChallengeComplete implements TabCompleter {
 
+    ChallengesOutsourcing cho = ChallengesPluginNeo.getInstance().getCho();
+    ChallengesPluginNeo instance = ChallengesPluginNeo.getInstance();
+
     @Override
     public @Nullable List<String> onTabComplete(@NotNull CommandSender commandSender, @NotNull Command command, @NotNull String s, @NotNull String[] strings) {
 
-        if (strings.length == 1) {
-            List<String> list = new ArrayList<>();
-            list.add("random");
-            return list;
+        List<String> list = new ArrayList<>();
+
+        switch (strings.length) {
+            case 1:
+                list.add("random");
+                list.add("sync");
+                break;
+            case 2:
+                instance.log(strings[0] + " " + cho.isValidType(strings[0]), Debuglevel.LEVEL_4);
+                if (cho.isValidType(strings[0])) {
+                    cho.getChallengesFromType(strings[0]).forEach(challenge -> {
+                        list.add(challenge.getName());
+                    });
+                }
+                break;
+            case 3:
+                list.add("true");
+                list.add("false");
+                list.add("on");
+                list.add("off");
         }
 
-        if (strings.length == 2) {
-            List<String> list = new ArrayList<>();
-            list.add("randomblocksloottable");
-            list.add("randomblocksfull");
-            list.add("randommobsloottable");
-            list.add("randommobsfull");
-            return list;
-        }
-
-        if (strings.length == 3) {
-            List<String> list = new ArrayList<>();
-            list.add("true");
-            list.add("false");
-            list.add("on");
-            list.add("off");
-            return list;
-        }
-
-        return null;
+        return list;
     }
 
 }

--- a/src/main/java/com/ciryusmedia/challengenetwork/challengespluginneo/outsourcing/ChallengesOutsourcing.java
+++ b/src/main/java/com/ciryusmedia/challengenetwork/challengespluginneo/outsourcing/ChallengesOutsourcing.java
@@ -18,6 +18,8 @@ public class ChallengesOutsourcing {
 
     public final List<Challenge> CHALLENGES = new ArrayList<>();
 
+    public final List<String> TYPES = new ArrayList<>();
+
     //Random Challenges
     public final Challenge RANDOM_BLOCKS_LOOTTABLE = new RandomBlocksLoottable();
     public final Challenge RANDOM_BLOCKS_FULL = new RandomBlocksFull();
@@ -36,6 +38,10 @@ public class ChallengesOutsourcing {
         CHALLENGES.add(INVENTORY_SYNC);
 
         CHALLENGES.forEach(challenge -> {challenge.setEnabled(plugin.getConfig().getBoolean(challenge.getName()));});
+
+        //Subtypes
+        TYPES.add("random");
+        TYPES.add("sync");
     }
 
     public Challenge getChallengeFromName(String name) {
@@ -54,6 +60,20 @@ public class ChallengesOutsourcing {
         });
 
         return challenges;
+    }
+
+    public List<Challenge> getChallengesFromType(String subtype) {
+        List<Challenge> challenges = new ArrayList<>();
+
+        CHALLENGES.forEach(c -> {
+            if (c.getType().equalsIgnoreCase(subtype)) challenges.add(c);
+        });
+
+        return challenges;
+    }
+
+    public boolean isValidType(String subtype) {
+        return TYPES.contains(subtype);
     }
 
     public ChallengesOutsourcing() {


### PR DESCRIPTION
The tabcompleter for the /challenge command is now modular instead of hardcoded, as it checks if a challenge type is valid and displays challenges that are of said type